### PR TITLE
Update Expecto version to 7.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: csharp
 sudo: required
 dist: trusty
-mono: none
-dotnet: 2.0.0
+mono: 5.8.0
+dotnet: 2.1.101
 
 env:
   global:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,4 +1,5 @@
 <Project>
+  <Import Project="./build/Mono.DotNetCore.props" />
   <PropertyGroup>
     <Authors>Aleksander Heintz</Authors>
     <Product>YoloDev Expecto TestSdk</Product>
@@ -13,7 +14,8 @@
 
   <!-- Versions -->
   <PropertyGroup>
-    <ExpectoVersion>6.0.0</ExpectoVersion>
+    <ExpectoVersion>7.0.0</ExpectoVersion>
     <TestSdkVersion>15.5.0</TestSdkVersion>
+    <FSharpCoreVersion>4.3.2</FSharpCoreVersion>
   </PropertyGroup>
 </Project>

--- a/build/Mono.DotNetCore.props
+++ b/build/Mono.DotNetCore.props
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) Microsoft Corporation.  All Rights Reserved.  See License.txt in the project root for license information. -->
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- When compiling .NET SDK 2.0 projects targeting .NET 4.x on Mono using 'dotnet build' you -->
+    <!-- have to teach MSBuild where the Mono copy of the reference asssemblies is -->
+    <TargetIsMono Condition="$(TargetFramework.StartsWith('net4')) and '$(OS)' == 'Unix'">true</TargetIsMono>
+    
+    <!-- Look in the standard install locations -->
+    <BaseFrameworkPathOverrideForMono Condition="'$(BaseFrameworkPathOverrideForMono)' == '' AND '$(TargetIsMono)' == 'true' AND EXISTS('/Library/Frameworks/Mono.framework/Versions/Current/lib/mono')">/Library/Frameworks/Mono.framework/Versions/Current/lib/mono</BaseFrameworkPathOverrideForMono>
+    <BaseFrameworkPathOverrideForMono Condition="'$(BaseFrameworkPathOverrideForMono)' == '' AND '$(TargetIsMono)' == 'true' AND EXISTS('/usr/lib/mono')">/usr/lib/mono</BaseFrameworkPathOverrideForMono>
+    <BaseFrameworkPathOverrideForMono Condition="'$(BaseFrameworkPathOverrideForMono)' == '' AND '$(TargetIsMono)' == 'true' AND EXISTS('/usr/local/lib/mono')">/usr/local/lib/mono</BaseFrameworkPathOverrideForMono>
+
+    <!-- If we found Mono reference assemblies, then use them -->
+    <FrameworkPathOverride Condition="'$(BaseFrameworkPathOverrideForMono)' != '' AND '$(TargetFramework)' == 'net45'">$(BaseFrameworkPathOverrideForMono)/4.5-api</FrameworkPathOverride>
+    <FrameworkPathOverride Condition="'$(BaseFrameworkPathOverrideForMono)' != '' AND '$(TargetFramework)' == 'net451'">$(BaseFrameworkPathOverrideForMono)/4.5.1-api</FrameworkPathOverride>
+    <FrameworkPathOverride Condition="'$(BaseFrameworkPathOverrideForMono)' != '' AND '$(TargetFramework)' == 'net452'">$(BaseFrameworkPathOverrideForMono)/4.5.2-api</FrameworkPathOverride>
+    <FrameworkPathOverride Condition="'$(BaseFrameworkPathOverrideForMono)' != '' AND '$(TargetFramework)' == 'net46'">$(BaseFrameworkPathOverrideForMono)/4.6-api</FrameworkPathOverride>
+    <FrameworkPathOverride Condition="'$(BaseFrameworkPathOverrideForMono)' != '' AND '$(TargetFramework)' == 'net461'">$(BaseFrameworkPathOverrideForMono)/4.6.1-api</FrameworkPathOverride>
+    <FrameworkPathOverride Condition="'$(BaseFrameworkPathOverrideForMono)' != '' AND '$(TargetFramework)' == 'net462'">$(BaseFrameworkPathOverrideForMono)/4.6.2-api</FrameworkPathOverride>
+    <FrameworkPathOverride Condition="'$(BaseFrameworkPathOverrideForMono)' != '' AND '$(TargetFramework)' == 'net47'">$(BaseFrameworkPathOverrideForMono)/4.7-api</FrameworkPathOverride>
+    <FrameworkPathOverride Condition="'$(BaseFrameworkPathOverrideForMono)' != '' AND '$(TargetFramework)' == 'net471'">$(BaseFrameworkPathOverrideForMono)/4.7.1-api</FrameworkPathOverride>
+    <EnableFrameworkPathOverride Condition="'$(BaseFrameworkPathOverrideForMono)' != ''">true</EnableFrameworkPathOverride>
+
+  </PropertyGroup>
+</Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <DebugType>portable</DebugType>
     <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSUnixLike())">netcoreapp2.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/YoloDev.Expecto.TestSdk/YoloDev.Expecto.TestSdk.fsproj
+++ b/src/YoloDev.Expecto.TestSdk/YoloDev.Expecto.TestSdk.fsproj
@@ -32,6 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="FSharp.Core" Version="$(FSharpCoreVersion)" />
     <PackageReference Include="Expecto" Version="$(ExpectoVersion)" />
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="$(TestSdkVersion)" PrivateAssets="All" />
     <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FSharp.Core" Version="$(FSharpCoreVersion)" />
     <PackageReference Include="Expecto" Version="$(ExpectoVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)\..\src\YoloDev.Expecto.TestSdk\YoloDev.Expecto.TestSdk.fsproj" />

--- a/test/Sample.Test/Sample.Test.fsproj
+++ b/test/Sample.Test/Sample.Test.fsproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net462</TargetFrameworks>
+    <OutputType>exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Based off work from https://github.com/atlemann/dotnet-test-workaround we can use a set of frameworkoverrides provided by the Don https://github.com/dotnet/sdk/issues/335#issuecomment-368669050 that allow building netfull on mono with dotnet core tooling.  

Had to bump expecto version to 7.0 otherwise was getting an error 'executor://yolodev/expecto': Method 'Expecto.Impl.get_testFromAssembly' not found.
