### PR TITLE
Converting from netcoreapp2.0 to netstandard2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ nuget.exe
 .vscode/
 korebuild-lock.txt
 global.json
+.ionide/

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,11 +3,12 @@
 
   <PropertyGroup>
     <DebugType>portable</DebugType>
-    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FSharp.Core" Version="$(FSharpCoreVersion)" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="[2.5.0]" PrivateAssets="all" />
     <PackageReference Include="SourceLink.Test" Version="[2.5.0]" PrivateAssets="all" />
     <DotNetCliToolReference Include="dotnet-sourcelink" Version="[2.5.0]" />

--- a/src/YoloDev.Expecto.TestSdk/YoloDev.Expecto.TestSdk.fsproj
+++ b/src/YoloDev.Expecto.TestSdk/YoloDev.Expecto.TestSdk.fsproj
@@ -1,11 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName Condition=" '$(TargetFramework)' == 'net461' ">expecto.visualstudio.testadapter</AssemblyName>
-    <AssemblyName Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">expecto.visualstudio.dotnetcore.testadapter</AssemblyName>
+    <AssemblyName Condition=" '$(TargetFramework)' == 'netstandard2.0' ">expecto.visualstudio.dotnetcore.testadapter</AssemblyName>
     <!-- puts build outputs in build folder in nupkg -->
     <BuildOutputTargetFolder>build</BuildOutputTargetFolder>
     <OutputType>Library</OutputType>
-    <OutputType Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,13 +15,12 @@
     <Compile Include="discovery.fs" />
     <Compile Include="execution.fs" />
     <Compile Include="adapter.fs" />
-    <Compile Include="main.fs" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="build/netcoreapp2.0/YoloDev.Expecto.TestSdk.props">
+    <None Include="build/netstandard2.0/YoloDev.Expecto.TestSdk.props">
       <Pack>true</Pack>
-      <PackagePath>build\netcoreapp2.0\</PackagePath>
+      <PackagePath>build\netstandard2.0\</PackagePath>
     </None>
 
     <None Include="build/net461/YoloDev.Expecto.TestSdk.props">

--- a/src/YoloDev.Expecto.TestSdk/main.fs
+++ b/src/YoloDev.Expecto.TestSdk/main.fs
@@ -1,6 +1,0 @@
-module YoloDev.Expecto.TestSdk.Main
-
-#if NETCOREAPP2_0
-[<EntryPoint>]
-let main _ = failwithf "YoloDev.Expecto.TestSdk is not intended to be run as a program"
-#endif


### PR DESCRIPTION
closes #13 

This converts the main lib from `netcoreapp2.0` to `netstandard2.0`.  This should remove the dependency on `Microsoft.NETCore.App` in the nuget package. 

I also had to pin `FSharp.Core` to 4.3.2 in the src repo because the latest dotnet sdk will infer 4.5 otherwise.

I suggest a pre-release package to see if this does break anything downstream.