### PR TITLE
Update Expecto version constraint

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,9 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryRoot>$(MSBuildThisFileDirectory)</RepositoryRoot>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>$(NoWarn);NU5125</NoWarn>
     <DebugType>embedded</DebugType>
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
   </PropertyGroup>
 
   <!-- Versions -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
 
   <!-- Versions -->
   <PropertyGroup>
-    <ExpectoVersion>7.0.0</ExpectoVersion>
+    <ExpectoVersion>[7.0, 8.0)</ExpectoVersion>
     <TestSdkVersion>15.5.0</TestSdkVersion>
     <FSharpCoreVersion>4.3.2</FSharpCoreVersion>
   </PropertyGroup>


### PR DESCRIPTION
This is the first of 2 PRs that will address the binary incompatibility introduced in Expecto v8 as outlined in #15 