### PR TITLE
Use the expecto DU for config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ nuget.exe
 .vscode/
 korebuild-lock.txt
 global.json
+.ionide/

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ os:
   - linux
   - osx
 
-osx_image: xcode8.2
+osx_image: xcode10.2
 
 before_install:
   - if test "$TRAVIS_OS_NAME" == "osx"; then brew update; brew install openssl; ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/; ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/; fi

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,8 +16,8 @@
 
   <!-- Versions -->
   <PropertyGroup>
-    <ExpectoVersion>[8.4, 9.0)</ExpectoVersion>
+    <ExpectoVersion>[8.9.0, 9.0)</ExpectoVersion>
     <TestSdkVersion>15.5.0</TestSdkVersion>
-    <FSharpCoreVersion>4.3.2</FSharpCoreVersion>
+    <FSharpCoreVersion>4.3.4</FSharpCoreVersion>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
 
   <!-- Versions -->
   <PropertyGroup>
-    <ExpectoVersion>[8.9.0, 9.0)</ExpectoVersion>
+    <ExpectoVersion>[8.10.0, 9.0)</ExpectoVersion>
     <TestSdkVersion>15.5.0</TestSdkVersion>
     <FSharpCoreVersion>4.3.4</FSharpCoreVersion>
   </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ RunSettings arguments:
   Example: dotnet test -- MSTest.DeploymentEnabled=false MSTest.MapInconclusiveToFailed=True
   ```
 
-Many of the [ExpectoConfig](https://github.com/haf/expecto#the-config) settings are settable throughusing the CLI or .runsettings file.  This test adapter has chosen to use the naming from  Expecto's [CLI arguments](https://github.com/haf/expecto#main-argv--how-to-run-console-apps) without the `--`.  You must also prefix `Expecto.` to the front of the parameter. Additionally any args that are a switch must take a boolean value.
+Many of the [ExpectoConfig](https://github.com/haf/expecto#the-config) settings are settable throughusing the CLI or .runsettings file.  This test adapter uses the naming from  Expecto's [CLI arguments](https://github.com/haf/expecto#main-argv--how-to-run-console-apps) (without the leading `--`), namespaced with `Expecto.`. Additionally, any args that are switches must take a boolean value.
 
 #### RunSettings Example: 
 

--- a/README.md
+++ b/README.md
@@ -3,3 +3,28 @@
 | Windows                                                                                                                                                                           | Mac / Linux                                                                                                                                                     |
 | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [![Build history](https://buildstats.info/appveyor/chart/YoloDev/yolodev-expecto-testsdk?branch=master)](https://ci.appveyor.com/project/YoloDev/yolodev-expecto-testsdk/history) | [![Build history](https://buildstats.info/travisci/chart/YoloDev/YoloDev.Expecto.TestSdk?branch=master)](https://travis-ci.org/YoloDev/YoloDev.Expecto.TestSdk) |
+
+
+## Configuration
+
+You can configure some of Expecto via `dotnet test`. `dotnet test` allows you to pass in `RunSettings` via the [CLI](#dotnet-test-runsettings) or using a [.runsettings](https://docs.microsoft.com/en-us/visualstudio/test/configure-unit-tests-by-using-a-dot-runsettings-file?view=vs-2017#example-runsettings-file) file. 
+
+### dotnet test RunSettings 
+
+To familiarize yourself with how dotnet test expects the CLI args, the help from it is shown below.
+
+```
+RunSettings arguments:
+  Arguments to pass as RunSettings configurations. Arguments are specified as '[name]=[value]' pairs after "-- " (note the space after --).
+  Use a space to separate multiple '[name]=[value]' pairs.
+  See https://aka.ms/vstest-runsettings-arguments for more information on RunSettings arguments.
+  Example: dotnet test -- MSTest.DeploymentEnabled=false MSTest.MapInconclusiveToFailed=True
+  ```
+
+Many of the [ExpectoConfig](https://github.com/haf/expecto#the-config) settings are settable throughusing the CLI or .runsettings file.  This test adapter has chosen to use the naming from  Expecto's [CLI arguments](https://github.com/haf/expecto#main-argv--how-to-run-console-apps) without the `--`.  You must also prefix `Expecto.` to the front of the parameter. Additionally any args that are a switch must take a boolean value.
+
+#### RunSettings Example: 
+
+```
+dotnet test -- Expecto.parallel=false Expecto.fail-on-focused-tests=true Expecto.stress-memory-limit=120.0 
+```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You can configure some of Expecto via `dotnet test`. `dotnet test` allows you to
 
 ### dotnet test RunSettings 
 
-To familiarize yourself with how dotnet test expects the CLI args, the help from it is shown below.
+From dotnet test cli help:
 
 ```
 RunSettings arguments:

--- a/README.md
+++ b/README.md
@@ -13,13 +13,12 @@ You can configure some of Expecto via `dotnet test`. `dotnet test` allows you to
 
 From dotnet test cli help:
 
-```
-RunSettings arguments:
-  Arguments to pass as RunSettings configurations. Arguments are specified as '[name]=[value]' pairs after "-- " (note the space after --).
-  Use a space to separate multiple '[name]=[value]' pairs.
-  See https://aka.ms/vstest-runsettings-arguments for more information on RunSettings arguments.
-  Example: dotnet test -- MSTest.DeploymentEnabled=false MSTest.MapInconclusiveToFailed=True
-  ```
+> RunSettings arguments:
+>   Arguments to pass as RunSettings configurations. Arguments are specified as '[name]=[value]' pairs after "-- " (note the space after --).
+>   Use a space to separate multiple '[name]=[value]' pairs.
+>   See https://aka.ms/vstest-runsettings-arguments for more information on RunSettings arguments.
+>   Example: dotnet test -- MSTest.DeploymentEnabled=false MSTest.MapInconclusiveToFailed=True
+
 
 Many of the [ExpectoConfig](https://github.com/haf/expecto#the-config) settings are settable throughusing the CLI or .runsettings file.  This test adapter uses the naming from  Expecto's [CLI arguments](https://github.com/haf/expecto#main-argv--how-to-run-console-apps) (without the leading `--`), namespaced with `Expecto.`. Additionally, any args that are switches must take a boolean value.
 

--- a/src/YoloDev.Expecto.TestSdk/adapter.fs
+++ b/src/YoloDev.Expecto.TestSdk/adapter.fs
@@ -13,7 +13,7 @@ open Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging
 [<ExtensionUri(Constants.executorUriString)>]
 type VsTestAdapter () =
   let cts = new CancellationTokenSource ()
-
+  
   interface System.IDisposable with
     member x.Dispose () =
       match cts with
@@ -32,7 +32,7 @@ type VsTestAdapter () =
       let runSettings =
         Option.ofObj discoveryContext
         |> Option.bind (fun c -> Option.ofObj c.RunSettings)
-        |> Option.map RunSettings.read
+        |> Option.map (RunSettings.read logger)
         |> Option.defaultValue RunSettings.defaultSettings
 
       let testPlatformContext = {
@@ -57,7 +57,7 @@ type VsTestAdapter () =
       let runSettings =
         Option.ofObj runContext
         |> Option.bind (fun c -> Option.ofObj c.RunSettings)
-        |> Option.map RunSettings.read
+        |> Option.map (RunSettings.read logger)
         |> Option.defaultValue RunSettings.defaultSettings
       
       Execution.runSpecifiedTests logger runSettings.expectoConfig frameworkHandle tests
@@ -74,7 +74,7 @@ type VsTestAdapter () =
       let runSettings =
         Option.ofObj runContext
         |> Option.bind (fun c -> Option.ofObj c.RunSettings)
-        |> Option.map RunSettings.read
+        |> Option.map (RunSettings.read logger)
         |> Option.defaultValue RunSettings.defaultSettings
 
       let testPlatformContext = {

--- a/src/YoloDev.Expecto.TestSdk/adapter.fs
+++ b/src/YoloDev.Expecto.TestSdk/adapter.fs
@@ -60,7 +60,7 @@ type VsTestAdapter () =
         |> Option.map RunSettings.read
         |> Option.defaultValue RunSettings.defaultSettings
       
-      Execution.runSpecifiedTests logger frameworkHandle tests
+      Execution.runSpecifiedTests logger runSettings.expectoConfig frameworkHandle tests
       |> Async.RunSynchronously
 
     member x.RunTests (sources: string seq, runContext: IRunContext, frameworkHandle: IFrameworkHandle) : unit =
@@ -81,5 +81,5 @@ type VsTestAdapter () =
         requireSourceInformation = runSettings.collectSourceInformation
         requireTestProperty = true }
       
-      Execution.runTests logger frameworkHandle sources
+      Execution.runTests logger runSettings.expectoConfig frameworkHandle sources
       |> Async.RunSynchronously

--- a/src/YoloDev.Expecto.TestSdk/execution.fs
+++ b/src/YoloDev.Expecto.TestSdk/execution.fs
@@ -130,7 +130,7 @@ module Execution =
     let getLogger = LogAdapter.create logger (Some <| ExpectoTest.source test)
     let printAdapter = PrinterAdapter.create discovered frameworkHandle
 
-    let config = { config with printer = printAdapter }
+    let config = CLIArguments.Printer printAdapter :: config
     Expecto.Logging.Global.initialise <| { Expecto.Logging.Global.defaultConfig with getLogger = getLogger }
     
     let testNames =
@@ -144,7 +144,9 @@ module Execution =
 
     let duplicates = duplicatedNames tests
     match duplicates with
-    | [] -> Expecto.Impl.runEval config tests |> Async.Ignore
+    | [] -> 
+      Expecto.Tests.runTestsWithCLIArgs config [||] tests |> ignore
+      async.Zero ()
     | _  ->
       Logger.send LogLevel.Error (Some <| ExpectoTest.source test) (sprintf "Found duplicated test names, these names are: %A" duplicates) logger
       async.Zero ()

--- a/src/YoloDev.Expecto.TestSdk/helpers.fs
+++ b/src/YoloDev.Expecto.TestSdk/helpers.fs
@@ -43,7 +43,7 @@ module internal TryParse =
     | true,v -> Some v
     | _ -> None
 
-  let float32 (str : string) =
+  let float (str : string) =
     match Double.TryParse str with
     | true,v -> Some v
     | _ -> None

--- a/src/YoloDev.Expecto.TestSdk/helpers.fs
+++ b/src/YoloDev.Expecto.TestSdk/helpers.fs
@@ -37,3 +37,13 @@ module internal TryParse =
     match Boolean.TryParse str with
     | true, v -> Some v
     | _ -> None
+
+  let int32 (str : string) =
+    match Int32.TryParse str with
+    | true,v -> Some v
+    | _ -> None
+
+  let float32 (str : string) =
+    match Double.TryParse str with
+    | true,v -> Some v
+    | _ -> None

--- a/src/YoloDev.Expecto.TestSdk/settings.fs
+++ b/src/YoloDev.Expecto.TestSdk/settings.fs
@@ -4,6 +4,8 @@ module internal YoloDev.Expecto.TestSdk.Settings
 open Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter
 open Expecto.Impl
 open Expecto.Tests
+open System
+open Expecto
 
 type RunSettings = 
   { /// Gets a value which indicates whether we should attempt to get source line information.
@@ -29,48 +31,146 @@ module RunSettings =
       disableParallelization = false
       targetFrameworkVersion = None
       expectoConfig = ExpectoConfig.defaultConfig }
-  
+
+  let private foldCLIArgumentToConfig = function
+    | Sequenced -> fun o -> { o with ``parallel`` = false }
+    | Parallel -> fun o -> { o with ``parallel`` = true }
+    | Parallel_Workers n -> fun o -> { o with parallelWorkers = n }
+    | Stress_Timeout n -> fun o -> { o with stressTimeout = TimeSpan.FromMinutes n }
+    | Stress_Memory_Limit n -> fun o -> { o with stressMemoryLimit = n }
+    | Fail_On_Focused_Tests -> fun o -> { o with failOnFocusedTests = true }
+    | Debug -> fun o -> { o with verbosity = Expecto.Logging.LogLevel.Debug }
+    | Log_Name name -> fun o -> { o with logName = Some name }
+    | Filter hiera -> fun o -> {o with filter = Test.filter (fun s -> s.StartsWith hiera )}
+    | Run tests -> fun o -> {o with filter = Test.filter (fun s -> tests |> List.exists ((=) s) )}
+    | FsCheck_Max_Tests n -> fun o -> {o with fsCheckMaxTests = n }
+    | FsCheck_Start_Size n -> fun o -> {o with fsCheckStartSize = n }
+    | FsCheck_End_Size n -> fun o -> {o with fsCheckEndSize = Some n }
+    | Allow_Duplicate_Names -> fun o -> { o with allowDuplicateNames = true }
+    | No_Spinner -> fun o -> { o with noSpinner = true }
+    | _ -> id
+
+  let readValueParse parser elementName confNode =
+      confNode
+      |> Option.bind (Xml.element elementName)
+      |> Option.bind Xml.value
+      |> Option.bind parser
+
+  let readValueString elementName confNode = readValueParse Option.ofObj elementName confNode
+  let readValueBool elementName confNode = readValueParse TryParse.bool elementName confNode
+  let readValueInt32 elementName confNode = readValueParse TryParse.int32 elementName confNode
+  let readValueFloat32 elementName confNode = readValueParse TryParse.float32 elementName confNode
+
+  let readExpectoConfig expectoConfig (confNode: Xml.Linq.XElement option) =
+    let parallelTests = 
+      readValueBool "parallel" 
+      >> Option.map ( function | true -> CLIArguments.Parallel | false -> CLIArguments.Sequenced)
+    let parallelWorkers = 
+      readValueInt32 "parallel-workers"
+      >> Option.map CLIArguments.Parallel_Workers
+    let stress = 
+      readValueFloat32 "stress"
+      >> Option.map CLIArguments.Stress
+    let stressTimeout = 
+      readValueFloat32 "stress-timeout"
+      >> Option.map CLIArguments.Stress_Timeout
+    let stressMemoryLimit = 
+      readValueFloat32 "stress-memory-limit"
+      >> Option.map CLIArguments.Stress_Memory_Limit
+    let failOnFocusedTests =
+      readValueBool "fail-on-focused-tests"
+      >> Option.bind ( function | true -> Some CLIArguments.Fail_On_Focused_Tests | false -> None)
+    let debug =
+      readValueBool "debug"
+      >> Option.bind ( function | true -> Some CLIArguments.Debug | false -> None)
+    let logName =
+      readValueString "log-name"
+      >> Option.map CLIArguments.Log_Name
+    let filter =
+      readValueString "filter"
+      >> Option.map CLIArguments.Filter
+    //TODO: Run_tests.  Need to figure out how to parse it
+    let fsCheckMaxTests =
+      readValueInt32 "fscheck-max-tests"
+      >> Option.map CLIArguments.FsCheck_Max_Tests
+    let fsCheckStartSize =
+      readValueInt32 "fscheck-start-size"
+      >> Option.map CLIArguments.FsCheck_Start_Size
+    let fsCheckEndSize =
+      readValueInt32 "fscheck-end-size"
+      >> Option.map CLIArguments.FsCheck_End_Size
+    let allowDuplicateNames =
+      readValueBool "allow-duplicate-name"
+      >> Option.bind (function | true -> Some CLIArguments.Allow_Duplicate_Names | false -> None)
+    let spinner =
+      readValueBool "no-spinner"
+      >> Option.bind (function | true -> Some CLIArguments.No_Spinner | false -> None)
+
+    let args =
+      [
+        parallelTests
+        parallelWorkers
+        stress
+        stressTimeout
+        stressMemoryLimit
+        failOnFocusedTests
+        debug
+        logName
+        filter
+        fsCheckMaxTests
+        fsCheckStartSize
+        fsCheckEndSize
+        allowDuplicateNames
+        spinner
+      ]
+      |> Seq.choose (fun readSetting -> readSetting confNode)
+
+    (expectoConfig, args)
+    ||> Seq.fold(fun state next -> foldCLIArgumentToConfig next state)
+    
+
   let read (runSettings: IRunSettings) =
     let settings = defaultSettings
-    
-    let confNode = 
+    let runSettingsNode =
       Option.ofObj runSettings
       |> Option.bind (fun s -> Option.ofObj s.SettingsXml)
       |> Option.bind Xml.read
-      |> Option.bind Xml.root
-      |> Option.bind (Xml.element "RunSettings")
+      |> Option.bind Xml.root //This gets the RunSettings element
+    let confNode = 
+      runSettingsNode
       |> Option.bind (Xml.element "RunConfiguration")
     
     let settings = 
       confNode
-      |> Option.bind (Xml.element "DisableParallelization")
-      |> Option.bind Xml.value
-      |> Option.bind TryParse.bool
+      |> readValueBool "DisableParallelization"
       |> Option.map (fun v -> { settings with disableParallelization = v })
       |> Option.defaultValue settings
     
     let settings = 
       confNode
-      |> Option.bind (Xml.element "DesignMode")
-      |> Option.bind Xml.value
-      |> Option.bind TryParse.bool
+      |> readValueBool "DesignMode"
       |> Option.map (fun v -> { settings with designMode = v })
       |> Option.defaultValue settings
     
     let settings = 
       confNode
-      |> Option.bind (Xml.element "CollectSourceInformation")
-      |> Option.bind Xml.value
-      |> Option.bind TryParse.bool
+      |> readValueBool "CollectSourceInformation"
       |> Option.map (fun v -> { settings with collectSourceInformation = v })
       |> Option.defaultValue settings
     
     let settings = 
       confNode
-      |> Option.bind (Xml.element "TargetFrameworkVersion")
-      |> Option.bind Xml.value
+      |> readValueString "TargetFrameworkVersion"
       |> Option.map (fun v -> { settings with targetFrameworkVersion = Some v })
       |> Option.defaultValue settings
+
+    let expectoRunSettings = 
+      runSettingsNode
+      |> Option.bind (Xml.element "Expecto")
+
+    let settings = 
+      { settings 
+        with expectoConfig = readExpectoConfig settings.expectoConfig expectoRunSettings }
     settings
 
 type TestPlatformContext = 

--- a/src/YoloDev.Expecto.TestSdk/settings.fs
+++ b/src/YoloDev.Expecto.TestSdk/settings.fs
@@ -52,16 +52,21 @@ module RunSettings =
     | No_Spinner -> fun o -> { o with noSpinner = true }
     | Filter_Test_List _ -> id
     | Filter_Test_Case _  -> id
-    // Not applicable 
+    // Not applicable
     | List_Tests -> id
-    // Not applicable 
+    // Not applicable
     | Summary -> id
-    // Not applicable 
+    // Not applicable
     | Summary_Location -> id
-    // Not applicable 
+    // Not applicable
     | Version -> id
+    // Not applicable
+    | My_Spirit_Is_Weak -> id
+    // Not applicable, printer gets overriden in execution.fs
+    | Printer _ -> id
+    | Verbosity l -> fun o -> { o with verbosity = l }
     // Not applicable 
-    | My_Spirit_Is_Weak -> id 
+    | Append_Summary_Handler(_) -> id
 
   let readValueParse parser elementName confNode =
       confNode
@@ -103,6 +108,7 @@ module RunSettings =
       | Element "fscheck-end-size" (Int i) -> Some (CLIArguments.FsCheck_End_Size i)
       | Element "allow-duplicate-name" (Bool true) -> Some CLIArguments.Allow_Duplicate_Names
       | Element "no-spinner" (Bool true) -> Some CLIArguments.No_Spinner
+      | Element "verbosity" (String s) -> Expecto.Logging.LogLevel.ofString s |> CLIArguments.Verbosity |> Some
       | _ -> None
 
     let args =

--- a/src/YoloDev.Expecto.TestSdk/settings.fs
+++ b/src/YoloDev.Expecto.TestSdk/settings.fs
@@ -129,7 +129,7 @@ module RunSettings =
       Option.ofObj runSettings
       |> Option.bind (fun s -> Option.ofObj s.SettingsXml)
       |> Option.bind Xml.read
-      |> Option.bind Xml.root //This gets the RunSettings element
+      |> Option.bind Xml.root
 
     let confNode = 
       runSettingsNode
@@ -168,11 +168,7 @@ module RunSettings =
       |> Option.map(readExpectoConfig logger settings.expectoConfig)
       |> Option.defaultValue settings.expectoConfig
 
-    let settings = 
-      { settings 
-        with expectoConfig =  expectoConfig }
-    
-    settings
+    { settings with expectoConfig =  expectoConfig }
 
 type TestPlatformContext = 
   { /// Indicates if VSTestCase object must have FileName or LineNumber information.

--- a/src/YoloDev.Expecto.TestSdk/settings.fs
+++ b/src/YoloDev.Expecto.TestSdk/settings.fs
@@ -34,6 +34,8 @@ module RunSettings =
       targetFrameworkVersion = None
       expectoConfig = ExpectoConfig.defaultConfig }
 
+  /// Derived from Expecto https://github.com/haf/expecto/blob/dd1f486183cc5f2198b016b04285f5be7cfc8866/Expecto/Expecto.fs
+  /// If made public https://github.com/haf/expecto/issues/307 this can go away
   let private foldCLIArgumentToConfig = function
     | Sequenced -> fun o -> { o with ``parallel`` = false }
     | Parallel -> fun o -> { o with ``parallel`` = true }

--- a/src/YoloDev.Expecto.TestSdk/settings.fs
+++ b/src/YoloDev.Expecto.TestSdk/settings.fs
@@ -2,6 +2,8 @@
 module internal YoloDev.Expecto.TestSdk.Settings
 
 open Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter
+open Expecto.Impl
+open Expecto.Tests
 
 type RunSettings = 
   { /// Gets a value which indicates whether we should attempt to get source line information.
@@ -14,7 +16,10 @@ type RunSettings =
     disableParallelization: bool
 
     /// Gets a value which indicates the target framework the tests are being run in.
-    targetFrameworkVersion: string option }
+    targetFrameworkVersion: string option 
+
+    /// Gets the [ExpectoConfig](https://github.com/haf/expecto#the-config) that was set via RunSettings
+    expectoConfig : ExpectoConfig}
 
 [<RequireQualifiedAccess>]
 module RunSettings = 
@@ -22,9 +27,10 @@ module RunSettings =
     { collectSourceInformation = true
       designMode = true
       disableParallelization = false
-      targetFrameworkVersion = None }
+      targetFrameworkVersion = None
+      expectoConfig = ExpectoConfig.defaultConfig }
   
-  let read (runSettings: IRunSettings) = 
+  let read (runSettings: IRunSettings) =
     let settings = defaultSettings
     
     let confNode = 
@@ -65,7 +71,6 @@ module RunSettings =
       |> Option.bind Xml.value
       |> Option.map (fun v -> { settings with targetFrameworkVersion = Some v })
       |> Option.defaultValue settings
-    
     settings
 
 type TestPlatformContext = 


### PR DESCRIPTION
Switch to use the new Expecto CLIArguments DU instead of creating our own config object. Hopefully this will stop Expecto from breaking us every few months. This includes the changes from @TheAngryByrd which enables setting some of the expecto settings using run settings, however I've removed some of them again. It also sets `fail-on-focused-tests` to true by default, which is a breaking change.

Co authored by: @TheAngryByrd <jimmybyrd@gmail.com>
Fixes: #15 
Fixes: #20
Closes: #21
Semver: minor