### PR TITLE
Restore net461 support and add tests for net461.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
         run: dotnet msbuild build/build.proj -target:Test -p:NoRestore=true -p:VSTestNoBuild=true
 
   pack:
+    if: github.ref == 'refs/heads/master'
     name: Create package
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
   pack:
     if: github.ref == 'refs/heads/master'
     name: Create package
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     needs:
       - test
 
@@ -85,9 +85,6 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: "3.1.201"
-
-      - name: Setup side by side .NET SDKs on *nix
-        run: rsync -a ${DOTNET_ROOT/3.1.201/2.1.805}/* $DOTNET_ROOT/
 
       - name: Print dotnet info
         run: dotnet --info
@@ -114,7 +111,7 @@ jobs:
   publish:
     if: github.ref == 'refs/heads/master'
     name: Publish package
-    runs-on: ubuntu-latest
+    runs-on: linux-latest
     needs:
       - pack
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,13 +56,13 @@ jobs:
         run: bash ./script/git-version.sh --verbose get
 
       - name: Restore
-        run: dotnet msbuild build/build.proj -target:Restore -v:d
+        run: dotnet msbuild build/build.proj -target:Restore
 
       - name: Build
-        run: dotnet msbuild build/build.proj -target:Build -p:NoRestore=true -v:d
+        run: dotnet msbuild build/build.proj -target:Build -p:NoRestore=true
 
       - name: Test
-        run: dotnet msbuild build/build.proj -target:Test -p:NoRestore=true -p:VSTestNoBuild=true -v:d
+        run: dotnet msbuild build/build.proj -target:Test -p:NoRestore=true -p:VSTestNoBuild=true
 
   pack:
     name: Create package
@@ -99,10 +99,10 @@ jobs:
         run: bash ./script/git-version.sh --verbose get
 
       - name: Restore
-        run: dotnet msbuild build/build.proj -target:Restore -v:d
+        run: dotnet msbuild build/build.proj -target:Restore
 
       - name: Create nuget packages
-        run: dotnet msbuild build/build.proj -target:Pack -v:d
+        run: dotnet msbuild build/build.proj -target:Pack
 
       - name: Upload nuget packages as artifact
         uses: actions/upload-artifact@v1

--- a/YoloDev.Expecto.TestSdk.sln
+++ b/YoloDev.Expecto.TestSdk.sln
@@ -1,15 +1,14 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30114.128
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{FCE4C28E-CF2A-423F-9E7A-8A13DAACBF96}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "YoloDev.Expecto.TestSdk", "src\YoloDev.Expecto.TestSdk\YoloDev.Expecto.TestSdk.fsproj", "{06D3B976-762E-4645-B70E-C87B1EDE1CEE}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "YoloDev.Expecto.TestSdk", "src\YoloDev.Expecto.TestSdk\YoloDev.Expecto.TestSdk.fsproj", "{06D3B976-762E-4645-B70E-C87B1EDE1CEE}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{C5F68231-8575-44BC-B2CD-5163268E8A45}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Sample.Test", "test\Sample.Test\Sample.Test.fsproj", "{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Sample.Test", "test\Sample.Test\Sample.Test.fsproj", "{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -20,37 +19,40 @@ Global
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Debug|x64.ActiveCfg = Debug|x64
-		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Debug|x64.Build.0 = Debug|x64
-		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Debug|x86.ActiveCfg = Debug|x86
-		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Debug|x86.Build.0 = Debug|x86
+		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Debug|x64.Build.0 = Debug|Any CPU
+		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Debug|x86.Build.0 = Debug|Any CPU
 		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Release|Any CPU.Build.0 = Release|Any CPU
-		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Release|x64.ActiveCfg = Release|x64
-		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Release|x64.Build.0 = Release|x64
-		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Release|x86.ActiveCfg = Release|x86
-		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Release|x86.Build.0 = Release|x86
+		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Release|x64.ActiveCfg = Release|Any CPU
+		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Release|x64.Build.0 = Release|Any CPU
+		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Release|x86.ActiveCfg = Release|Any CPU
+		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Release|x86.Build.0 = Release|Any CPU
 		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Debug|x64.ActiveCfg = Debug|x64
-		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Debug|x64.Build.0 = Debug|x64
-		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Debug|x86.ActiveCfg = Debug|x86
-		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Debug|x86.Build.0 = Debug|x86
+		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Debug|x64.Build.0 = Debug|Any CPU
+		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Debug|x86.Build.0 = Debug|Any CPU
 		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Release|x64.ActiveCfg = Release|x64
-		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Release|x64.Build.0 = Release|x64
-		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Release|x86.ActiveCfg = Release|x86
-		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Release|x86.Build.0 = Release|x86
+		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Release|x64.ActiveCfg = Release|Any CPU
+		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Release|x64.Build.0 = Release|Any CPU
+		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Release|x86.ActiveCfg = Release|Any CPU
+		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{06D3B976-762E-4645-B70E-C87B1EDE1CEE} = {FCE4C28E-CF2A-423F-9E7A-8A13DAACBF96}
 		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE} = {C5F68231-8575-44BC-B2CD-5163268E8A45}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {516965F3-AB6F-4C00-9E53-2CBBF62F96D4}
 	EndGlobalSection
 EndGlobal

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,6 +10,9 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Update="Microsoft.SourceLink.GitHub" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <DebugType>portable</DebugType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/YoloDev.Expecto.TestSdk/YoloDev.Expecto.TestSdk.fsproj
+++ b/src/YoloDev.Expecto.TestSdk/YoloDev.Expecto.TestSdk.fsproj
@@ -1,10 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk; Microsoft.Build.CentralPackageVersions">
+<Project Sdk="Microsoft.NET.Sdk; Microsoft.Build.CentralPackageVersions">
 
   <PropertyGroup>
     <AssemblyName>expecto.visualstudio.dotnetcore.testadapter</AssemblyName>
     <!-- puts build outputs in build folder in nupkg -->
     <BuildOutputTargetFolder>build</BuildOutputTargetFolder>
-    <OutputType>Exe</OutputType>
     <PackageId>$(MSBuildProjectName)</PackageId>
   </PropertyGroup>
 
@@ -16,7 +15,6 @@
     <Compile Include="discovery.fs" />
     <Compile Include="execution.fs" />
     <Compile Include="adapter.fs" />
-    <Compile Include="main.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/YoloDev.Expecto.TestSdk/main.fs
+++ b/src/YoloDev.Expecto.TestSdk/main.fs
@@ -1,4 +1,0 @@
-module YoloDev.Expecto.TestSdk.Main
-
-[<EntryPoint>]
-let main _ = failwithf "YoloDev.Expecto.TestSdk is not intended to be run as a program"

--- a/test/Sample.Test/Sample.Test.fsproj
+++ b/test/Sample.Test/Sample.Test.fsproj
@@ -4,6 +4,9 @@
     <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
     <OutputType>library</OutputType>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+  </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="Test.fs" />

--- a/test/Sample.Test/Sample.Test.fsproj
+++ b/test/Sample.Test/Sample.Test.fsproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk; Microsoft.Build.CentralPackageVersions">
+<Project Sdk="Microsoft.NET.Sdk; Microsoft.Build.CentralPackageVersions">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
     <OutputType>library</OutputType>
   </PropertyGroup>
 


### PR DESCRIPTION
### The relevant part of the CI build logs:
* netcoreapp2.1 tests - https://github.com/YoloDev/YoloDev.Expecto.TestSdk/pull/34/checks?check_run_id=725231794#step:12:26
* net461 tests - https://github.com/YoloDev/YoloDev.Expecto.TestSdk/pull/34/checks?check_run_id=725231794#step:12:11

### How did I test it?
I ran the tests from VS 2019 and observed them being run in the CI.
![image](https://user-images.githubusercontent.com/8547855/83358448-f2e6cd00-a373-11ea-83f5-8d82bd441ce2.png)
