### PR TITLE
Revert net461 and allow System.Collections.Immutable 5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,18 +56,17 @@ jobs:
         run: bash ./script/git-version.sh --verbose get
 
       - name: Restore
-        run: dotnet msbuild build/build.proj -target:Restore
+        run: dotnet msbuild build/build.proj -target:Restore -v:d
 
       - name: Build
-        run: dotnet msbuild build/build.proj -target:Build -p:NoRestore=true
+        run: dotnet msbuild build/build.proj -target:Build -p:NoRestore=true -v:d
 
       - name: Test
-        run: dotnet msbuild build/build.proj -target:Test -p:NoRestore=true -p:VSTestNoBuild=true
+        run: dotnet msbuild build/build.proj -target:Test -p:NoRestore=true -p:VSTestNoBuild=true -v:d
 
   pack:
-    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
     name: Create package
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     needs:
       - test
 
@@ -86,6 +85,9 @@ jobs:
         with:
           dotnet-version: "3.1.201"
 
+      - name: Setup side by side .NET SDKs on *nix
+        run: rsync -a ${DOTNET_ROOT/3.1.201/2.1.805}/* $DOTNET_ROOT/
+
       - name: Print dotnet info
         run: dotnet --info
 
@@ -97,10 +99,10 @@ jobs:
         run: bash ./script/git-version.sh --verbose get
 
       - name: Restore
-        run: dotnet msbuild build/build.proj -target:Restore
+        run: dotnet msbuild build/build.proj -target:Restore -v:d
 
       - name: Create nuget packages
-        run: dotnet msbuild build/build.proj -target:Pack
+        run: dotnet msbuild build/build.proj -target:Pack -v:d
 
       - name: Upload nuget packages as artifact
         uses: actions/upload-artifact@v1

--- a/Packages.props
+++ b/Packages.props
@@ -8,7 +8,7 @@
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
     <PackageReference Update="Microsoft.TestPlatform.ObjectModel" Version="16.6.1" PrivateAssets="All" />
-    <PackageReference Update="System.Collections.Immutable" Version="[1.5.0, 2.0)" />
+    <PackageReference Update="System.Collections.Immutable" Version="[1.5.0, 5.1)" />
   </ItemGroup>
 
 </Project>

--- a/YoloDev.Expecto.TestSdk.sln
+++ b/YoloDev.Expecto.TestSdk.sln
@@ -1,14 +1,15 @@
+
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30114.128
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{FCE4C28E-CF2A-423F-9E7A-8A13DAACBF96}"
 EndProject
-Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "YoloDev.Expecto.TestSdk", "src\YoloDev.Expecto.TestSdk\YoloDev.Expecto.TestSdk.fsproj", "{06D3B976-762E-4645-B70E-C87B1EDE1CEE}"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "YoloDev.Expecto.TestSdk", "src\YoloDev.Expecto.TestSdk\YoloDev.Expecto.TestSdk.fsproj", "{06D3B976-762E-4645-B70E-C87B1EDE1CEE}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{C5F68231-8575-44BC-B2CD-5163268E8A45}"
 EndProject
-Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Sample.Test", "test\Sample.Test\Sample.Test.fsproj", "{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Sample.Test", "test\Sample.Test\Sample.Test.fsproj", "{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -19,40 +20,37 @@ Global
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Debug|x64.Build.0 = Debug|Any CPU
-		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Debug|x86.Build.0 = Debug|Any CPU
+		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Debug|x64.ActiveCfg = Debug|x64
+		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Debug|x64.Build.0 = Debug|x64
+		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Debug|x86.ActiveCfg = Debug|x86
+		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Debug|x86.Build.0 = Debug|x86
 		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Release|Any CPU.Build.0 = Release|Any CPU
-		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Release|x64.ActiveCfg = Release|Any CPU
-		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Release|x64.Build.0 = Release|Any CPU
-		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Release|x86.ActiveCfg = Release|Any CPU
-		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Release|x86.Build.0 = Release|Any CPU
+		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Release|x64.ActiveCfg = Release|x64
+		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Release|x64.Build.0 = Release|x64
+		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Release|x86.ActiveCfg = Release|x86
+		{06D3B976-762E-4645-B70E-C87B1EDE1CEE}.Release|x86.Build.0 = Release|x86
 		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Debug|x64.Build.0 = Debug|Any CPU
-		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Debug|x86.Build.0 = Debug|Any CPU
+		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Debug|x64.ActiveCfg = Debug|x64
+		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Debug|x64.Build.0 = Debug|x64
+		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Debug|x86.ActiveCfg = Debug|x86
+		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Debug|x86.Build.0 = Debug|x86
 		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Release|x64.ActiveCfg = Release|Any CPU
-		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Release|x64.Build.0 = Release|Any CPU
-		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Release|x86.ActiveCfg = Release|Any CPU
-		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Release|x86.Build.0 = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
+		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Release|x64.ActiveCfg = Release|x64
+		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Release|x64.Build.0 = Release|x64
+		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Release|x86.ActiveCfg = Release|x86
+		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{06D3B976-762E-4645-B70E-C87B1EDE1CEE} = {FCE4C28E-CF2A-423F-9E7A-8A13DAACBF96}
 		{2DADC6BD-672C-4B40-B0DA-0C6AD4F372BE} = {C5F68231-8575-44BC-B2CD-5163268E8A45}
-	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {516965F3-AB6F-4C00-9E53-2CBBF62F96D4}
 	EndGlobalSection
 EndGlobal

--- a/script/git-version.sh
+++ b/script/git-version.sh
@@ -232,7 +232,11 @@ function get-branch-point() {
 
 	local branch=$1
 	local base=$2
-	diff -u <(git rev-list --first-parent "$branch") <(git rev-list --first-parent "$base") | sed -ne 's/^ //p' | head -1
+	if [ "$verbose" = true ]; then
+		diff -u <(git rev-list --first-parent "$branch" 2>&3) <(git rev-list --first-parent "$base" 2>&3) | sed -ne 's/^ //p' | head -1
+	else
+		diff -u <(git rev-list --first-parent "$branch" 2>/dev/null ) <(git rev-list --first-parent "$base" 2>/dev/null) | sed -ne 's/^ //p' | head -1
+	fi
 }
 
 function get-commit-count() {

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,15 +3,12 @@
 
   <PropertyGroup>
     <DebugType>portable</DebugType>
-    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>true</IsPackable>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/YoloDev.Expecto.TestSdk/YoloDev.Expecto.TestSdk.fsproj
+++ b/src/YoloDev.Expecto.TestSdk/YoloDev.Expecto.TestSdk.fsproj
@@ -1,9 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk; Microsoft.Build.CentralPackageVersions">
+﻿<Project Sdk="Microsoft.NET.Sdk; Microsoft.Build.CentralPackageVersions">
 
   <PropertyGroup>
     <AssemblyName>expecto.visualstudio.dotnetcore.testadapter</AssemblyName>
     <!-- puts build outputs in build folder in nupkg -->
     <BuildOutputTargetFolder>build</BuildOutputTargetFolder>
+    <OutputType>Exe</OutputType>
     <PackageId>$(MSBuildProjectName)</PackageId>
   </PropertyGroup>
 
@@ -15,6 +16,7 @@
     <Compile Include="discovery.fs" />
     <Compile Include="execution.fs" />
     <Compile Include="adapter.fs" />
+    <Compile Include="main.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/YoloDev.Expecto.TestSdk/main.fs
+++ b/src/YoloDev.Expecto.TestSdk/main.fs
@@ -1,0 +1,4 @@
+module YoloDev.Expecto.TestSdk.Main
+
+[<EntryPoint>]
+let main _ = failwithf "YoloDev.Expecto.TestSdk is not intended to be run as a program"

--- a/test/Sample.Test/Sample.Test.fsproj
+++ b/test/Sample.Test/Sample.Test.fsproj
@@ -1,11 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk; Microsoft.Build.CentralPackageVersions">
+﻿<Project Sdk="Microsoft.NET.Sdk; Microsoft.Build.CentralPackageVersions">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>library</OutputType>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I reverted the changes connected to the failed attempt to support net461 and was able to do created the package locally on Ubuntu.

Release notes of System.Collections.Immutable ( https://github.com/dotnet/core/blob/master/release-notes/5.0/netstandard2.1/5.0-preview5_System.Collections.Immutable.md ) suggest that only new stuff has been added to the package, so I assume that it is safe to raise the upper bond of constraint on the version of the package.

Fixes #38 