### PR TITLE
Remove upper version constraint on System.Collections.Immutable

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
     <PackageVersion Include="FSharp.Core" Version="[4.6.0,)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="16.11.0" />
-    <PackageVersion Include="System.Collections.Immutable" Version="[1.5.0, 5.1)" />
+    <PackageVersion Include="System.Collections.Immutable" Version="[1.5.0,)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This is to resolve #74 and allow .NET 6.0 projects with dependencies on System.Collections.Immutable greater than 5.1 to use the test SDK