### PR TITLE
fix: missing .props file

### DIFF
--- a/src/YoloDev.Expecto.TestSdk/YoloDev.Expecto.TestSdk.fsproj
+++ b/src/YoloDev.Expecto.TestSdk/YoloDev.Expecto.TestSdk.fsproj
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="build/net6.0/YoloDev.Expecto.TestSdk.props" Pack="true" PackagePath="build\net6.0\" />
     <None Include="build/net6.0/_._" Pack="true" PackagePath="lib\net6.0\" Visible="false" />
   </ItemGroup>
 

--- a/src/YoloDev.Expecto.TestSdk/build/net6.0/YoloDev.Expecto.TestSdk.props
+++ b/src/YoloDev.Expecto.TestSdk/build/net6.0/YoloDev.Expecto.TestSdk.props
@@ -1,0 +1,10 @@
+<Project>
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)expecto.visualstudio.dotnetcore.testadapter.dll">
+      <Link>expecto.visualstudio.dotnetcore.testadapter.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Visible>False</Visible>
+    </None>
+    <ProjectCapability Include="TestContainer" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Re-add `YoloDev.Expecto.TestSdk.props` to fix #122.

Resolves: #122