### PR TITLE
Add `filter-test-case` to readExpectoConfig

### DIFF
--- a/src/YoloDev.Expecto.TestSdk/settings.fs
+++ b/src/YoloDev.Expecto.TestSdk/settings.fs
@@ -146,7 +146,9 @@ module RunSettings =
 
           "colours", SettingsParser.int >-> CLIArguments.Colours
 
-          "join-with", SettingsParser.string >-> CLIArguments.JoinWith ]
+          "join-with", SettingsParser.string >-> CLIArguments.JoinWith
+
+          "filter-test-case", SettingsParser.string >-> CLIArguments.Filter_Test_Case ]
 
     let args =
       confNode.Descendants()


### PR DESCRIPTION
## Description:

When trying to filter the Expecto test that I'd like to run with `filter-test-case`, I noticed that it was indeed not working.

Example command:

```bash
dotnet test -- Expecto.filter-test-case="Some string"
```

Then, after digging the code, I noticed that the values are passed to the Expecto command by the function [readExpectoConfig](https://github.com/YoloDev/YoloDev.Expecto.TestSdk/blob/main/src/YoloDev.Expecto.TestSdk/settings.fs#L120).

With this PR, I'm adding a new possible value that works with the `filter-test-case`.

Please let me know if you'd like something to change in order for this PR to be merged.

## Related issue:

Must close https://github.com/YoloDev/YoloDev.Expecto.TestSdk/issues/130.

## How to test:

```bash
# clone this repo
cd test/Sample.Test

# list all the available tests
dotnet test --list-tests

# filter the tests that are going to run
dotnet test -- Expecto.filter-test-case="test1"
dotnet test -- Expecto.filter-test-case="test4"

# assert that it ran only one test each time
```

![image](https://github.com/YoloDev/YoloDev.Expecto.TestSdk/assets/50725287/6b2a4c78-b4ac-4354-bcc8-bff3b5943be5)
