### PR TITLE
Is the System.Collections.Immutable NuGet package reference needed?

### DIFF
--- a/src/YoloDev.Expecto.TestSdk/YoloDev.Expecto.TestSdk.fsproj
+++ b/src/YoloDev.Expecto.TestSdk/YoloDev.Expecto.TestSdk.fsproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="YoloDev.Sdk">
+<Project Sdk="YoloDev.Sdk">
 
   <PropertyGroup>
     <AssemblyName>expecto.visualstudio.dotnetcore.testadapter</AssemblyName>
@@ -28,7 +28,6 @@
     <PackageReference Include="FSharp.Core" />
     <PackageReference Include="Expecto" />
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" PrivateAssets="all" />
-    <PackageReference Include="System.Collections.Immutable" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Hi,

Not sure if i'm missing something with the dependency, but -

I was doing some updates on things, and looking at dependencies, and wondered if there is a need to reference the v6 System.Collections.Immutable NuGet package in the .NET 6.0 build here as it's built in to that version, but then I don't actually see any code that uses it anyway - so - can it be removed?