### PR TITLE
Fix minimal version of Expecto

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,6 +1,6 @@
 <Project>
   <ItemGroup>
-    <PackageVersion Include="Expecto" Version="[10.0, 11.0)" />
+    <PackageVersion Include="Expecto" Version="[10.2.1, 11.0)" />
     <PackageVersion Include="FSharp.Core" Version="[7.0.200,)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.VSTestBridge" Version="1.5.3" />


### PR DESCRIPTION
You probably want to ship `0.15.1` with this fix in.