### PR TITLE
feat: use expecto printer compat layer

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,6 +1,6 @@
 <Project>
   <ItemGroup>
-    <PackageVersion Include="Expecto" Version="[10.2.1, 11.0)" />
+    <PackageVersion Include="Expecto" Version="[10.2.2, 11.0)" />
     <PackageVersion Include="FSharp.Core" Version="[7.0.200,)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.VSTestBridge" Version="1.6.2" />

--- a/src/YoloDev.Expecto.TestSdk/execution.fs
+++ b/src/YoloDev.Expecto.TestSdk/execution.fs
@@ -102,7 +102,7 @@ module private PrinterAdapter =
       result.Duration <- duration
       recordEnd result
 
-    Expecto.Impl.TestPrinters.silent
+    TestPrinters.silent
     |> TestPrinters.withBeforeEach beforeEach
     |> TestPrinters.withPassed passed
     |> TestPrinters.withIgnored ignored

--- a/src/YoloDev.Expecto.TestSdk/execution.fs
+++ b/src/YoloDev.Expecto.TestSdk/execution.fs
@@ -48,6 +48,7 @@ module private LogAdapter =
 
 module private PrinterAdapter =
   open System
+  type private TestPrinters = Expecto.Impl.TestPrinters
 
   let create (cases: Map<string, TestCase>) (frameworkHandle: IFrameworkHandle) =
     let results = Map.map (fun _ -> TestResult) cases
@@ -101,12 +102,12 @@ module private PrinterAdapter =
       result.Duration <- duration
       recordEnd result
 
-    { Expecto.Impl.TestPrinters.silent with
-        beforeEach = beforeEach
-        passed = passed
-        ignored = ignored
-        failed = failed
-        exn = exn }
+    Expecto.Impl.TestPrinters.silent
+    |> TestPrinters.withBeforeEach beforeEach
+    |> TestPrinters.withPassed passed
+    |> TestPrinters.withIgnored ignored
+    |> TestPrinters.withFailed failed
+    |> TestPrinters.withExn exn
 
 [<RequireQualifiedAccess>]
 module internal Execution =


### PR DESCRIPTION
#186 

## The change
Use TestPrinters builder to insulate YoloDev from printer signature changes

This should reduce the need to coordinated updates, allowing YoloDev to remain unchanged even if the underlying TestPrinters signature changes

Specifically, we plan to add an `isSkipped` parameter to the beforeEach printer.
As-is, that change breaks YoloDev. This change should fix that

I tested Expecto 11.0.0-alpha8 with these changes locally, and it worked as expected

## Problem

~~For unclear reasons, this change seems to have broken the YoloDev.Expecto.TestSdk project's ability to load in Visual Studio.
It says `The SDK 'Microsoft.NET.Sdk' specified could not be found.`~~
