### PR TITLE
fix: do not set the source path to an empty string

### DIFF
--- a/src/YoloDev.Expecto.TestSdk/discovery.fs
+++ b/src/YoloDev.Expecto.TestSdk/discovery.fs
@@ -13,7 +13,8 @@ module private TestCase =
     let case = TestCase(fullName, Constants.executorUri, source)
     let location = getLocation assembly test.test
     case.LineNumber <- location.lineNumber
-    case.CodeFilePath <- location.sourcePath
+    if location.sourcePath <> "" then
+      case.CodeFilePath <- location.sourcePath
     case
 
 type ExpectoTest =


### PR DESCRIPTION
[In certain cases](https://github.com/haf/expecto/blob/bdbc298307ebfc1368e6bf125a6a03929233bba1/Expecto/Expecto.Impl.fs#L989-L992), Expecto can fail to determine a test's source path, and returns an empty string, which confuses some other MTP plugins ([ref](https://github.com/Tyrrrz/GitHubActionsTestLogger/blob/b47a22f27100e4c90f2af20ed7cfd9be2e2ed539/GitHubActionsTestLogger/GitHub/GitHubEnvironment.cs#L55), [example failure](https://github.com/teo-tsirpanis/Farkle/actions/runs/24107447133/job/70334068541#step:7:404)). For this reason, an empty source path will translate to a null `CodeFilePath`.