### PR TITLE
feat: emit public TestMethodIdentifierProperty and stop advertising vstestProvider

### DIFF
--- a/src/YoloDev.Expecto.TestSdk/TestApplicationHelpers.fs
+++ b/src/YoloDev.Expecto.TestSdk/TestApplicationHelpers.fs
@@ -18,7 +18,7 @@ open Microsoft.Testing.Platform.Capabilities.TestFramework
 // consume the public properties and stop depending on the internal key/value-pair shape.
 //
 // This mirrors MSTest's MSTestCapabilities:
-// https://github.com/microsoft/testfx/blob/main/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/TestApplicationBuilderExtensions.cs
+// https://github.com/microsoft/testfx/blob/5c6ea3bf01f1247736fbbbba0ffdd8a8b38840dc/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/TestApplicationBuilderExtensions.cs
 // MSTest can implement the internal IInternalVSTestBridgeTrxReportCapability (it is on the bridge's
 // InternalsVisibleTo list); external adapters cannot, so we implement the public ITrxReportCapability.
 type internal ExpectoTestFrameworkCapabilities() =

--- a/src/YoloDev.Expecto.TestSdk/TestApplicationHelpers.fs
+++ b/src/YoloDev.Expecto.TestSdk/TestApplicationHelpers.fs
@@ -2,10 +2,29 @@ namespace YoloDev.Expecto.TestSdk
 
 open System.Reflection
 
-open Microsoft.Testing.Extensions.VSTestBridge.Capabilities
+open Microsoft.Testing.Extensions.TrxReport.Abstractions
 open Microsoft.Testing.Extensions.VSTestBridge.Helpers
 open Microsoft.Testing.Platform.Builder
 open Microsoft.Testing.Platform.Capabilities.TestFramework
+
+// We intentionally do NOT use VSTestBridgeExtensionBaseCapabilities because that type also implements
+// INamedFeatureCapability and advertises the "vstestProvider" capability. When a server advertises
+// vstestProvider, Visual Studio Test Explorer consumes the legacy "vstest.TestCase.*" properties
+// (serialized through Microsoft.Testing.Platform's internal SerializableKeyValuePairStringProperty
+// key/value bag) instead of the public, structured location.* properties.
+//
+// ExpectoTestFramework.AddAdditionalProperties now emits the public TestMethodIdentifierProperty
+// (serialized as location.type / location.method), so by not advertising vstestProvider we let the IDE
+// consume the public properties and stop depending on the internal key/value-pair shape.
+//
+// This mirrors MSTest's MSTestCapabilities:
+// https://github.com/microsoft/testfx/blob/main/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/TestApplicationBuilderExtensions.cs
+// MSTest can implement the internal IInternalVSTestBridgeTrxReportCapability (it is on the bridge's
+// InternalsVisibleTo list); external adapters cannot, so we implement the public ITrxReportCapability.
+type internal ExpectoTestFrameworkCapabilities() =
+  interface ITrxReportCapability with
+    member _.IsSupported = true
+    member _.Enable() = ()
 
 module TestApplicationBuilderExtensions =
   let addExpectoFramework (getTestAssemblies: unit -> Assembly seq) (builder: ITestApplicationBuilder) =
@@ -13,7 +32,7 @@ module TestApplicationBuilderExtensions =
     builder.AddRunSettingsService expectoExtension
     builder.AddTestCaseFilterService expectoExtension
     builder.RegisterTestFramework (
-      (fun _ -> TestFrameworkCapabilities(VSTestBridgeExtensionBaseCapabilities())),
+      (fun _ -> TestFrameworkCapabilities(ExpectoTestFrameworkCapabilities())),
       (fun capabilities serviceProvider -> new ExpectoTestFramework(expectoExtension, getTestAssemblies, serviceProvider, capabilities))
     ) |> ignore
 

--- a/src/YoloDev.Expecto.TestSdk/adapter.fs
+++ b/src/YoloDev.Expecto.TestSdk/adapter.fs
@@ -5,6 +5,7 @@ open System.Threading
 open System.Diagnostics
 open Microsoft.Testing.Extensions.VSTestBridge
 open Microsoft.Testing.Extensions.VSTestBridge.Requests
+open Microsoft.Testing.Platform.Extensions.Messages
 open Microsoft.VisualStudio.TestPlatform.ObjectModel
 open Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter
 open System.Threading.Tasks
@@ -128,3 +129,23 @@ type ExpectoTestFramework(extension, getTestAssemblies, serviceProvider, capabil
 
   override _.SynchronizedDiscoverTestsAsync(request, _, _) = discoverTests request
   override _.SynchronizedRunTestsAsync(request, _, token) = runTests request token
+
+  // Expecto tests are values in nested test lists, not CLR methods, so there is no real managed
+  // type/method. We synthesize a public TestMethodIdentifierProperty from the (dot-joined)
+  // FullyQualifiedName so Visual Studio can recover namespace/class/method via location.type /
+  // location.method without the legacy vstest.TestCase.* key/value-pair properties.
+  // NOTE: this assumes the default `--join-with .` separator; per-row identity relies on TestNode.Uid.
+  override _.AddAdditionalProperties(testNode: TestNode, testCase: TestCase) =
+    let fqn = testCase.FullyQualifiedName
+    if not (System.String.IsNullOrEmpty fqn) then
+      let lastDot = fqn.LastIndexOf '.'
+      let typeName, methodName =
+        if lastDot > 0 then fqn.Substring(0, lastDot), fqn.Substring(lastDot + 1)
+        else "", fqn
+      let assemblyFullName =
+        try AssemblyName.GetAssemblyName(testCase.Source).FullName
+        with _ -> ""
+      let property =
+        TestMethodIdentifierProperty(
+          assemblyFullName, "", typeName, methodName, 0, Array.empty<string>, "System.Void")
+      testNode.Properties.Add property

--- a/src/YoloDev.Expecto.TestSdk/execution.fs
+++ b/src/YoloDev.Expecto.TestSdk/execution.fs
@@ -80,8 +80,13 @@ module private PrinterAdapter =
       result.Outcome <- TestOutcome.Skipped
       result.EndTime <- DateTimeOffset.Now
 
-      result.Messages.Add
-      <| TestResultMessage(TestResultMessage.AdditionalInfoCategory, sprintf "Skipped: %s" reason)
+      // Surface the skip reason via ErrorMessage rather than a TestResultMessage with
+      // AdditionalInfoCategory. The Microsoft.Testing.Platform VSTest bridge only knows how to
+      // convert StandardError/StandardOut/DebugTrace message categories when building the TRX
+      // report and throws UnreachableException on any other category, so an AdditionalInfo message
+      // crashes the MTP run. For skipped tests the bridge maps ErrorMessage to
+      // SkippedTestNodeStateProperty, and the legacy VSTest runner also shows it as the skip reason.
+      result.ErrorMessage <- sprintf "Skipped: %s" reason
 
       recordEnd result
 


### PR DESCRIPTION
> ⚠️ **Draft / proposal** for discussion — see #283 for the full background.

## What

Emit the **public** `TestMethodIdentifierProperty` from the Expecto adapter and stop advertising the Microsoft.Testing.Platform `vstestProvider` capability, so Visual Studio Test Explorer consumes the public structured node properties instead of the legacy `vstest.TestCase.*` key/value-pair properties.

## Why

When the adapter advertises `vstestProvider`, VS routes Expecto through a legacy parser that reads `vstest.TestCase.*` properties, serialized via Microsoft.Testing.Platform''s **internal** `SerializableKeyValuePairStringProperty` key/value bag. The testfx team is deprecating that internal type in favor of public property types. MSTest already moved off this path; NUnit and Expecto are the last two adapters using it (companion NUnit PR: nunit/nunit3-vs-adapter#1456).

## How

1. **`adapter.fs`** — override `AddAdditionalProperties` to emit a `TestMethodIdentifierProperty` (serialized as `location.type` / `location.method`). Expecto tests are values in nested lists, not CLR methods, so this is **synthesized** from the dot-joined `FullyQualifiedName`.
2. **`TestApplicationHelpers.fs`** — replace `VSTestBridgeExtensionBaseCapabilities` (which also implements `INamedFeatureCapability("vstestProvider")`) with a small capability implementing only the public `ITrxReportCapability`. Mirrors MSTest''s [`MSTestCapabilities`](https://github.com/microsoft/testfx/blob/main/src/Adapter/MSTest.TestAdapter/TestingPlatformAdapter/TestApplicationBuilderExtensions.cs#L21-L31).
3. **`Directory.Packages.props`** — bump `Microsoft.Testing.*` from `1.9.1` to `2.2.3`. The `AddAdditionalProperties` virtual hook on the bridge base type is newer than `1.9.1`, so the override does not compile against `1.9.1`.

Builds clean (`net8.0`).

## Open questions / please review before this leaves draft

- **Type/method synthesis** (`adapter.fs`): the `FullyQualifiedName` is split on the last `.` into `location.type` / `location.method`. This assumes the default `--join-with .`; with `--join-with /` the split is wrong. There may be a better mapping from Expecto''s test hierarchy — your call.
- **Package bump (1.9.1 → 2.2.3):** flagging in case you were intentionally pinned to `1.x`.

## Identity & sequencing (important)

This change is the right *direction* but should be sequenced with the VS Test Explorer side, not landed in isolation:

- **Per-test identity** moves from the legacy `vstest.TestCase.Id` GUID to the public `TestNode.Uid`. Expecto''s `FullyQualifiedName` is already a unique per-test path, so the synthesized `location.type`/`location.method` preserves per-test identity reasonably well (better than the NUnit method-parameterized case) — but it remains a heuristic split.
- **`vstest.original-executor-uri` is dropped** (the bridge only emits it under `vstestProvider`). It is used for framework identity (e.g. "Associate to Test Case"). This is at **parity with MSTest**, which already runs without it on the public path; if a framework-identity feature depends on it, that is a shared testfx gap (needs a *public* identity property), not Expecto-specific.
- **TRX enrichment becomes always-on** with the public `ITrxReportCapability` (the internal on-demand gate isn''t available to external adapters). Harmless on the server-mode wire.

Please coordinate with the VS Test Explorer team so navigation / grouping / Test Case association don''t regress before `vstestProvider` is fully dropped.

Refs #283
