### PR TITLE
deps: update mstest monorepo to v2 and run platform tests in MTP mode

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -15,12 +15,12 @@ clean:
   dotnet clean
 
 test-platform: pack
-  dotnet clean ./test/Sample.Test/Sample.Test.fsproj -v:quiet
-  dotnet test ./test/Sample.Test/Sample.Test.fsproj -p:EnableExpectoTestingPlatformIntegration=true -p:IncludeFailingTests=false
+  cd test/mtp && dotnet clean ../Sample.Test/Sample.Test.fsproj -v:quiet
+  cd test/mtp && dotnet test ../Sample.Test/Sample.Test.fsproj -p:EnableExpectoTestingPlatformIntegration=true -p:IncludeFailingTests=false
 
 test-platform-failing: pack
-  dotnet clean ./test/Sample.Test/Sample.Test.fsproj -v:quiet
-  dotnet test ./test/Sample.Test/Sample.Test.fsproj -p:EnableExpectoTestingPlatformIntegration=true -p:IncludeFailingTests=true
+  cd test/mtp && dotnet clean ../Sample.Test/Sample.Test.fsproj -v:quiet
+  cd test/mtp && dotnet test ../Sample.Test/Sample.Test.fsproj -p:EnableExpectoTestingPlatformIntegration=true -p:IncludeFailingTests=true
 
 test-legacy: pack
   dotnet clean ./test/Sample.Test/Sample.Test.fsproj -v:quiet

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
     <PackageVersion Include="Expecto" Version="[10.2.2,11.1.0]" />
     <PackageVersion Include="FSharp.Core" Version="[7.0.200,)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.VSTestBridge" Version="1.9.1" />
-    <PackageVersion Include="Microsoft.Testing.Platform.MSBuild" Version="1.9.1" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.VSTestBridge" Version="2.2.3" />
+    <PackageVersion Include="Microsoft.Testing.Platform.MSBuild" Version="2.2.3" />
     <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="18.7.0" />
   </ItemGroup>
 </Project>

--- a/test/mtp/README.md
+++ b/test/mtp/README.md
@@ -1,0 +1,17 @@
+# `test/mtp` runner launcher
+
+This directory exists only to provide a `global.json` that opts into the
+**Microsoft.Testing.Platform (MTP) mode** of `dotnet test`
+(`"test": { "runner": "Microsoft.Testing.Platform" }`).
+
+Starting with `Microsoft.Testing.Platform` v2 on the .NET 10+ SDK, the legacy
+"VSTest mode" path for running MTP test apps via `dotnet test` was removed, so
+the platform integration test must run through MTP mode instead.
+
+`dotnet test` resolves the test `runner` from the **current working directory's**
+`global.json`, while `YoloDev.Sdk` resolves the repository root (and therefore
+`version.txt`) from the **test project's** directory. The `test-platform`
+recipes in `.justfile` `cd` into this folder and point at
+`../Sample.Test/Sample.Test.fsproj`, so the platform tests run under the MTP
+runner while the legacy (VSTest) recipes keep running from the repo root under
+the default VSTest runner.

--- a/test/mtp/global.json
+++ b/test/mtp/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}


### PR DESCRIPTION
## What

Makes the repo compatible with the **Microsoft.Testing.Platform (MTP) v2** packages (the same bump as #282) and fixes the resulting CI failures.

## Why

PR #282 bumps `Microsoft.Testing.Extensions.VSTestBridge` and `Microsoft.Testing.Platform.MSBuild` from `1.9.1` to `2.2.3`. On the .NET 10+ SDK, MTP v2 **removes the legacy "VSTest mode"** path that let `dotnet test` run MTP test apps via the `VSTest` MSBuild target. The `test-platform` recipe therefore fails on every OS with:

```
Testing with VSTest target is no longer supported by Microsoft.Testing.Platform
on .NET 10 SDK and later. If you use dotnet test, you should opt-in to the new
dotnet test experience.
```

The supported opt-in is the new **MTP mode of `dotnet test`**, enabled via `global.json` (`"test": { "runner": "Microsoft.Testing.Platform" }`). There is no per-invocation/env-var override in the current SDK. But the repo also runs `check-legacy`, which exercises the **classic VSTest adapter** — and a VSTest (non-MTP) project is rejected when `global.json` forces the MTP runner. So a single repo-wide `global.json` runner can't serve both modes.

## How

`dotnet test` resolves the `runner` from the **current working directory's** `global.json`, whereas `YoloDev.Sdk` resolves the repository root (and `version.txt`) from the **test project's** directory. These are independent, so:

- Added `test/mtp/global.json` selecting the MTP runner.
- The `test-platform` / `test-platform-failing` recipes now `cd test/mtp` and point at `../Sample.Test/Sample.Test.fsproj`, running the platform integration tests in MTP mode.
- The legacy recipes are unchanged — they keep running from the repo root under the default VSTest runner.
- Bumped the two MTP packages to `2.2.3`.

## Verification

Ran the full matrix locally on the .NET 11 SDK (rolls forward from the pinned 10.0.301):

| Recipe | Result | Exit |
| --- | --- | --- |
| `test-platform` | tests pass | `0` |
| `test-platform-failing` | tests fail as expected | non-zero |
| `test-legacy` | tests pass | `0` |
| `test-legacy-failing` | tests fail as expected | non-zero |

Once this merges, the Renovate PR #282 becomes redundant.